### PR TITLE
update root node for sonar 7.6  test reports

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (runner) {
 	});
 
 	runner.on('end', function() {
-		append('<unitTest version="1">');
+		append('<testExecutions version="1">');
 		Object.keys(stack).forEach(function(file){
 			append(util.format('	<file path="%s">', file));
 			stack[file].forEach(function(test){
@@ -81,7 +81,7 @@ module.exports = function (runner) {
 			});
 			append('	</file>');
 		});
-		append('</unitTest>');
+		append('</testExecutions>');
 		fs.closeSync(fd);
 	});
 	function append(str) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"type": "git",
 		"url": "https://github.com/qingguo-yu/mocha-sonar-generic-test-coverage-file.git"
 	},
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"devDependencies": {
     "mocha": "^2.4.5"
   },


### PR DESCRIPTION
Updated root node of test report for sonar 7.6.

https://docs.sonarqube.org/latest/analysis/generic-test/